### PR TITLE
Fix example code in README considering changes of DataFrames

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Julia bindings for [LIBSVM](http://www.csie.ntu.edu.tw/~cjlin/libsvm/)
 using RDatasets, LIBSVM
 
 # Load Fisher's classic iris data
-iris = data("datasets", "iris")
+iris = dataset("datasets", "iris")
 
 # LIBSVM handles multi-class data automatically using a one-against-one strategy
-labels = iris["Species"].data
+labels = iris[:Species]
 
 # First dimension of input data is features; second is instances
-instances = transpose(matrix(iris[:, 2:5]))
+instances = array(iris[:, 1:4])'
 
 # Train SVM on half of the data using default parameters. See the svmtrain
 # function in LIBSVM.jl for optional parameter settings.


### PR DESCRIPTION
With DataFrames v0.5.4, sample codes makes following errors.
To avoid errors, I fix readme codes.

```
julia> iris = data("datasets", "iris")
ERROR: no method data(ASCIIString, ASCIIString)
```

```
julia> labels = iris["Species"].data
WARNING: indexing DataFrames with strings is deprecated; use symbols instead
 in getindex at /Users/mic/.julia/v0.3/DataFrames/src/deprecated.jl:120
ERROR: type PooledDataArray has no field data
```

```
julia> instances = transpose(matrix(iris[:, 2:5]))
ERROR: matrix not defined
```
