### PR TITLE
Avoid abstract types of fields in SupportVectors

### DIFF
--- a/src/LIBSVM.jl
+++ b/src/LIBSVM.jl
@@ -13,11 +13,11 @@ export svmtrain, svmpredict, fit!, predict, transform,
 include("LibSVMtypes.jl")
 include("constants.jl")
 
-struct SupportVectors{T,U}
+struct SupportVectors{T<:AbstractVector,U<:AbstractMatrix}
     l::Int32
     nSV::Vector{Int32}
-    y::AbstractVector{T}
-    X::AbstractMatrix{U}
+    y::T
+    X::U
     indices::Vector{Int32}
     SVnodes::Vector{SVMNode}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ end
     @info "test Whiteside"
 
     whiteside = RDatasets.dataset("MASS", "whiteside")
-    ws = convert(Matrix{Float64}, whiteside[:,2:3])
+    ws = Matrix{Float64}(whiteside[:,2:3])
     X = Array{Float64, 2}(ws[:, 2]')
     y = ws[:, 1]
 


### PR DESCRIPTION
I noticed that the `SupportVectors` structure contained two fields of abstract types. This PR fixes it.

EDIT: also fixed one test that threw errors