### PR TITLE
Call `svm_check_parameter` before training

### DIFF
--- a/src/LIBSVM.jl
+++ b/src/LIBSVM.jl
@@ -427,7 +427,6 @@ function svmpredict(model::SVM{T}, X::AbstractMatrix{U}; nt::Integer = 0) where 
           (Ptr{Cvoid},), @cfunction(svmnoprint, Cvoid, (Ptr{UInt8},)))
 
     cmod, data = svmmodel(model)
-
     ma = [cmod]
 
     for i = 1:ninstances

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,5 +151,10 @@ end
     end
 end
 
+@testset "Check parameters" begin
+    bad_params = Dict(:svmtype => OneClassSVM, :probability => true)
+    @test_throws ArgumentError svmtrain(rand(2, 5), ones(5); bad_params...)
+end
+
 
 end  # @testset "LIBSVM"


### PR DESCRIPTION
LIBSVM provides function `svm_check_parameter` that validates the parameters given by `SVMParameter`. This PR calls this function before calling `svm_train`.

It also removes one unused return value.