### PR TITLE
Wrap `ccall`s with proper Julia functions

### DIFF
--- a/src/LIBSVM.jl
+++ b/src/LIBSVM.jl
@@ -399,9 +399,11 @@ function svmpredict(model::SVM{T}, X::AbstractMatrix{U}; nt::Integer = 0) where 
 
     for i = 1:ninstances
         if model.probability
-            output = libsvm_predict_probability(cmod, nodeptrs[i], decvalues[:, i])
+            output = libsvm_predict_probability(cmod, nodeptrs[i],
+                                                Ref(decvalues, nlabels*(i-1)+1))
         else
-            output = libsvm_predict_values(cmod, nodeptrs[i], decvalues[:, i])
+            output = libsvm_predict_values(cmod, nodeptrs[i],
+                                           Ref(decvalues, nlabels*(i-1)+1))
         end
         if model.SVMtype == EpsilonSVR || model.SVMtype == NuSVR
             pred[i] = output

--- a/src/libcalls.jl
+++ b/src/libcalls.jl
@@ -35,7 +35,7 @@ end
 
 function libsvm_predict_probability(model::SVMModel, nodes::Ptr{SVMNode},
         decisions::Vector{Float64})
-    return ccall((:svm_predict_probability, libsvm), Float64,
+    return ccall((:svm_predict_probability, libsvm), Cdouble,
                  (Ref{SVMModel}, Ptr{SVMNode}, Ref{Float64}),
                  model, node, decisions)
 end

--- a/src/libcalls.jl
+++ b/src/libcalls.jl
@@ -34,14 +34,14 @@ function libsvm_free_model(model::Ptr{SVMModel})
 end
 
 function libsvm_predict_probability(model::SVMModel, nodes::Ptr{SVMNode},
-        decisions::Vector{Float64})
+        decisions::Ref{Float64})
     return ccall((:svm_predict_probability, libsvm), Cdouble,
                  (Ref{SVMModel}, Ptr{SVMNode}, Ref{Float64}),
                  model, node, decisions)
 end
 
 function libsvm_predict_values(model::SVMModel, nodes::Ptr{SVMNode},
-        decisions::Vector{Float64})
+        decisions::Ref{Float64})
     return ccall((:svm_predict_values, libsvm), Float64,
                  (Ref{SVMModel}, Ptr{SVMNode}, Ref{Float64}),
                  model, nodes, decisions)

--- a/src/libcalls.jl
+++ b/src/libcalls.jl
@@ -1,0 +1,48 @@
+function libsvm_get_max_threads()
+    return ccall((:svm_get_max_threads, libsvm), Cint, ())
+end
+
+function libsvm_set_num_threads(n::Integer)
+    ccall((:svm_set_num_threads, libsvm), Cvoid, (Cint,), n)
+end
+
+noprint(str::Ptr{UInt8})::Cvoid = nothing
+
+function libsvm_set_verbose(v::Bool)
+    f = ifelse(v, C_NULL, @cfunction(noprint, Cvoid, (Ptr{UInt8},)))
+    ccall((:svm_set_print_string_function, libsvm), Cvoid, (Ptr{Cvoid},), f)
+end
+
+function libsvm_check_parameter(problem::SVMProblem, param::SVMParameter)
+    err = ccall((:svm_check_parameter, libsvm), Cstring,
+                (Ref{SVMProblem}, Ref{SVMParameter}),
+                problem, param)
+    if err != C_NULL
+        throw(ArgumentError("Incorrect parameter: $(unsafe_string(err))"))
+    end
+end
+
+function libsvm_train(problem::SVMProblem, param::SVMParameter)
+    return ccall((:svm_train, libsvm), Ptr{SVMModel},
+                 (Ref{SVMProblem}, Ref{SVMParameter}),
+                 problem, param)
+end
+
+function libsvm_free_model(model::Ptr{SVMModel})
+    ccall((:svm_free_model_content, libsvm), Cvoid, (Ptr{SVMModel},),
+          model)
+end
+
+function libsvm_predict_probability(model::SVMModel, nodes::Ptr{SVMNode},
+        decisions::Vector{Float64})
+    return ccall((:svm_predict_probability, libsvm), Float64,
+                 (Ref{SVMModel}, Ptr{SVMNode}, Ref{Float64}),
+                 model, node, decisions)
+end
+
+function libsvm_predict_values(model::SVMModel, nodes::Ptr{SVMNode},
+        decisions::Vector{Float64})
+    return ccall((:svm_predict_values, libsvm), Float64,
+                 (Ref{SVMModel}, Ptr{SVMNode}, Ref{Float64}),
+                 model, nodes, decisions)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,6 @@ end
     end
 end
 
-
 @testset "AbstractVector as labels" begin
     @info "test AbstractVector labels"
 
@@ -67,7 +66,6 @@ end
     model = fit!(SVC(), Xtrain', ytrain)
     @test ŷ == predict(model, Xtest')
 end
-
 
 @testset "JLD2 save/load" begin
     @info "JLD2 save/load"
@@ -156,5 +154,18 @@ end
     @test_throws ArgumentError svmtrain(rand(2, 5), ones(5); bad_params...)
 end
 
+@testset "Decision values" begin
+    X = [-2 -1 -1 1 1 2;
+         -1 -1 -2 1 2 1]
+    y = [1, 1, 1, 2, 2, 2]
+    d = [1.5 1.0 1.5 -1.0 -1.5 -1.5;
+         0.0 0.0 0.0  0.0  0.0  0.0]
+
+    model = svmtrain(X, y, kernel=Kernel.Linear)
+    ỹ, d̃ = svmpredict(model, X)
+
+    @test ỹ == y
+    @test d ≈ d̃
+end
 
 end  # @testset "LIBSVM"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,7 +161,7 @@ end
     d = [1.5 1.0 1.5 -1.0 -1.5 -1.5;
          0.0 0.0 0.0  0.0  0.0  0.0]
 
-    model = svmtrain(X, y, kernel=Kernel.Linear)
+    model = svmtrain(X, y, kernel = Kernel.Linear)
     ỹ, d̃ = svmpredict(model, X)
 
     @test ỹ == y


### PR DESCRIPTION
Following #75, this PR wraps all calls to the LIBSVM C library with proper Julia functions. That way we get some type safety and it also makes the code cleaner.