### PR TITLE
cleanup duplicated libsvm_check_parameter call

### DIFF
--- a/src/LIBSVM.jl
+++ b/src/LIBSVM.jl
@@ -334,9 +334,6 @@ function svmtrain(
     end
     problem = SVMProblem(Int32(ninstances), pointer(idx), pointer(nodeptrs))
 
-    # Validate the given parameters
-    libsvm_check_parameter(problem, param)
-
     libsvm_set_verbose(verbose)
 
     @GC.preserve nodes begin


### PR DESCRIPTION
It has been invoked in the GC.preserve block.