### PR TITLE
Check dimension of gram matrix

### DIFF
--- a/src/LIBSVM.jl
+++ b/src/LIBSVM.jl
@@ -381,7 +381,7 @@ function svmpredict(model::SVM{T}, X::AbstractMatrix{U}; nt::Integer = 0) where 
     if model.kernel != Kernel.Precomputed && size(X, 1) != model.nfeatures
         throw(DimensionMismatch("Model has $(model.nfeatures) features but $(size(X, 1)) provided"))
     elseif model.kernel == Kernel.Precomputed && size(X, 1) != model.nfeatures
-            throw(DimensionMismatch("Gram matrix should either have $(model.nfeatures) or $(sum(model.SVs.nSV)) features but $(size(X, 1)) provided"))
+            throw(DimensionMismatch("Gram matrix should have $(model.nfeatures) but $(size(X, 1)) provided"))
     end
 
     ninstances = size(X, 2)

--- a/src/LIBSVM.jl
+++ b/src/LIBSVM.jl
@@ -109,7 +109,7 @@ function SVM(smc::SVMModel, y, X, weights, labels, svmtype, kernel)
     if kernel == Kernel.Precomputed
         nfeatures = size(X, 2)
     else
-        nfeatures = size(X,1)
+        nfeatures = size(X, 1)
     end
 
     SVM(svmtype, kernel, weights, nfeatures,

--- a/src/LIBSVM.jl
+++ b/src/LIBSVM.jl
@@ -374,22 +374,14 @@ K(t_i, x_2), ..., K(t_i, x_l)]`, where `t_i` is `i`-th testing instance and
 `x_j` is `j`-th training instance. For linear kernel, `M' * T` produces the
 correct matrix, where columns of `M` contain the training instances and columns
 of `T` the testing instances.
-Alternatively a shape of `(k, n)` is also accepted, where `k` is the number of
-support vectors of the model. The order should be the same as in `model.SVs.indices`.
 """
 function svmpredict(model::SVM{T}, X::AbstractMatrix{U}; nt::Integer = 0) where {T,U<:Real}
     set_num_threads(nt)
 
     if model.kernel != Kernel.Precomputed && size(X, 1) != model.nfeatures
         throw(DimensionMismatch("Model has $(model.nfeatures) features but $(size(X, 1)) provided"))
-    elseif model.kernel == Kernel.Precomputed
-        if size(X, 1) == sum(model.SVs.nSV)
-            X_sparse = copy(X)
-            X = similar(X_sparse, model.nfeatures, size(X, 2))
-            X[model.SVs.indices, :] = X_sparse
-        elseif size(X, 1) != model.nfeatures
+    elseif model.kernel == Kernel.Precomputed && size(X, 1) != model.nfeatures
             throw(DimensionMismatch("Gram matrix should either have $(model.nfeatures) or $(sum(model.SVs.nSV)) features but $(size(X, 1)) provided"))
-        end
     end
 
     ninstances = size(X, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,46 +290,6 @@ end
 
         @test_throws DimensionMismatch svmpredict(model, KK_malformed)
     end
-
-    @testset "Full gram matrix" begin
-        X = [-2 -1 -1 1 1 2;
-            -1 -1 -2 1 2 1]
-        y = [1, 1, 1, 2, 2, 2]
-
-        T = [-1 2 3;
-            -1 2 2]
-
-        ŷ = [1, 2, 2]
-
-        K = X' * X
-
-        model = svmtrain(K, y, kernel=Kernel.Precomputed)
-
-        KK = X' * T
-
-        ỹ, _ = svmpredict(model, KK)
-        @test ỹ == [1, 2, 2]
-    end
-
-    @testset "Sparse gram matrix" begin
-        X = [-2 -1 -1 1 1 2;
-            -1 -1 -2 1 2 1]
-        y = [1, 1, 1, 2, 2, 2]
-
-        T = [-1 2 3;
-            -1 2 2]
-
-        ŷ = [1, 2, 2]
-
-        K = X' * X
-
-        model = svmtrain(K, y, kernel=Kernel.Precomputed)
-
-        KK = X[:, model.SVs.indices]' * T
-
-        ỹ, _ = svmpredict(model, KK)
-        @test ỹ == [1, 2, 2]
-    end
 end
 
 end  # @testset "LIBSVM"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,6 +271,65 @@ end
         @test model.coefs ≈ model₂.coefs
         @test model.SVs.indices ≈ model₂.SVs.indices
     end
+
+    @testset "Malformed prediction" begin
+        X = [-2 -1 -1 1 1 2;
+            -1 -1 -2 1 2 1]
+        y = [1, 1, 1, 2, 2, 2]
+
+        T = [-1 2 3;
+            -1 2 2]
+
+        K = X' * X
+
+        model = svmtrain(K, y, kernel=Kernel.Precomputed)
+
+        KK = X' * T
+
+        KK_malformed = KK[1:1,:]
+
+        @test_throws DimensionMismatch svmpredict(model, KK_malformed)
+    end
+
+    @testset "Full gram matrix" begin
+        X = [-2 -1 -1 1 1 2;
+            -1 -1 -2 1 2 1]
+        y = [1, 1, 1, 2, 2, 2]
+
+        T = [-1 2 3;
+            -1 2 2]
+
+        ŷ = [1, 2, 2]
+
+        K = X' * X
+
+        model = svmtrain(K, y, kernel=Kernel.Precomputed)
+
+        KK = X' * T
+
+        ỹ, _ = svmpredict(model, KK)
+        @test ỹ == [1, 2, 2]
+    end
+
+    @testset "Sparse gram matrix" begin
+        X = [-2 -1 -1 1 1 2;
+            -1 -1 -2 1 2 1]
+        y = [1, 1, 1, 2, 2, 2]
+
+        T = [-1 2 3;
+            -1 2 2]
+
+        ŷ = [1, 2, 2]
+
+        K = X' * X
+
+        model = svmtrain(K, y, kernel=Kernel.Precomputed)
+
+        KK = X[:, model.SVs.indices]' * T
+
+        ỹ, _ = svmpredict(model, KK)
+        @test ỹ == [1, 2, 2]
+    end
 end
 
 end  # @testset "LIBSVM"


### PR DESCRIPTION
Resolves #85 
Checks that the gram matrix supplied to `svmpredict` has dimensions `(l, n)` when predicting `n` items on `l` training vectors or dimensions `(k, n)` where `k` is the number of support vectors of the model. If neither is the case, it will throw `DimensionMismatch`.

I have marked this pull request as a draft since I haven't been using Julia for very long and would appreciate some oversight. Additionally, I think whether to allow `(k, n)` shaped matrices might warrant some additional discussion.