### PR TITLE
Bump [compat] for LIBLINEAR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
-          - '1.4'
+          - '1.6'
           - '1'    # Latest Release
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LIBSVM"
 uuid = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 LIBLINEAR = "2d691ee1-e668-5016-a719-b2531b85e0f5"

--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,9 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 libsvm_jll = "08558c22-525a-5d2a-acf6-0ac6658ffce4"
 
 [compat]
-LIBLINEAR = "0.5, 0.6"
+LIBLINEAR = "0.5, 0.6, 0.7"
 ScikitLearnBase = "0.5"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 libsvm_jll = "08558c22-525a-5d2a-acf6-0ac6658ffce4"
 
 [compat]
-LIBLINEAR = "0.5, 0.6, 0.7"
+LIBLINEAR = "0.7"
 ScikitLearnBase = "0.5"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -144,12 +144,14 @@ The MLJ interface to LIBSVM.jl consists of the following models:
 
 Each model has a detailed document string, which includes examples of
 usage. Document strings can be accessed from MLJ without loading
-`LIBSVM.jl` or its MLJ interface as shown in the following example:
+`LIBSVM.jl` (or its MLJ interface) as shown in the following example:
 
 ```julia
 using MLJ     # or MLJModels 
 doc("NuSVC", pkg="LIBSVM")
 ```
+
+This assumes the version of MLJModels loaded is 0.15.5 or higher.
 
 Below we illustrate usage of the classic kernel `SVC` classifier. In
 the example, `X` can be replaced with any table (e.g., `DataFrame`)

--- a/README.md
+++ b/README.md
@@ -153,64 +153,6 @@ doc("NuSVC", pkg="LIBSVM")
 
 This assumes the version of MLJModels loaded is 0.15.5 or higher.
 
-Below we illustrate usage of the classic kernel `SVC` classifier. In
-the example, `X` can be replaced with any table (e.g., `DataFrame`)
-whose columns have `Float64` eltype. The target `y` can be any
-`CategoricalVector`.
-
-### Using a built-in kernel
-
-```
-using MLJ
-import LIBSVM
-
-SVC = @load SVC pkg=LIBSVM                   # model type
-model = SVC(kernel=LIBSVM.Kernel.Polynomial) # instance
-
-X, y = @load_iris # table, vector
-mach = machine(model, X, y) |> fit!
-
-Xnew = (sepal_length = [6.4, 7.2, 7.4],
-        sepal_width = [2.8, 3.0, 2.8],
-        petal_length = [5.6, 5.8, 6.1],
-        petal_width = [2.1, 1.6, 1.9],)
-
-julia> yhat = predict(mach, Xnew)
-3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
- "virginica"
- "virginica"
- "virginica"
-```
-
-### User-defined kernels
-
-```
-k(x1, x2) = x1'*x2 # equivalent to `LIBSVM.Kernel.Linear`
-model = SVC(kernel=k)
-mach = machine(model, X, y) |> fit!
-
-julia> yhat = predict(mach, Xnew)
-3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
- "virginica"
- "virginica"
- "virginica"
-```
-
-### Incorporating class weights
-
-In either scenario above, we can do:
-
-```julia
-weights = Dict("virginica" => 1, "versicolor" => 20, "setosa" => 1)
-mach = machine(model, X, y, weights) |> fit!
-
-julia> yhat = predict(mach, Xnew)
-3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
- "versicolor"
- "versicolor"
- "versicolor"
-```
-
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ julia> yhat = predict(mach, Xnew)
 
 ## Credits
 
-The library is currently developed and maintained by Matti Pastell. It was originally
-developed by Simon Kornblith.
+The LIBSVM.jl library is currently developed and maintained by Matti
+Pastell. It was originally developed by Simon Kornblith.
 
 [LIBSVM](http://www.csie.ntu.edu.tw/~cjlin/libsvm/) by Chih-Chung Chang and Chih-Jen Lin

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ model = fit!(EpsilonSVR(cost = 10., gamma = 1.), X, y)
 
 ### MLJ API
 
-The MLJ interface to LIBSVM.jl consists of the following models:
+The [MLJ](https://alan-turing-institute.github.io/MLJ.jl/dev/) interface to LIBSVM.jl consists of the following models:
 
 - classification: `LinearSVC`, `SVC`, `NuSVC` 
 - regression: `EpsilonSVR`, `NuSVR`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![Build Status](https://github.com/JuliaML/LIBSVM.jl/workflows/CI/badge.svg?branch=master)](https://github.com/JuliaML/LIBSVM.jl/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/JuliaML/LIBSVM.jl/branch/master/graph/badge.svg?token=bGwzyTtNPn)](https://codecov.io/gh/JuliaML/LIBSVM.jl)
 
-This is a Julia interface for [LIBSVM](http://www.csie.ntu.edu.tw/~cjlin/libsvm/).
+This is a Julia interface for
+[LIBSVM](http://www.csie.ntu.edu.tw/~cjlin/libsvm/) and for the linear
+SVM model provided by
+[LIBLINEAR](https://www.csie.ntu.edu.tw/~cjlin/liblinear/).
 
 **Features:**
 * Supports all LIBSVM models: classification C-SVC, nu-SVC, regression: epsilon-SVR, nu-SVR
@@ -130,6 +133,82 @@ y = whiteside.Temp
 model = fit!(EpsilonSVR(cost = 10., gamma = 1.), X, y)
 ŷ = predict(model, X)
 ```
+
+### MLJ API
+
+The MLJ interface to LIBSVM.jl consists of the following models:
+
+- classification: `LinearSVC`, `SVC`, `NuSVC` 
+- regression: `EpsilonSVR`, `NuSVR`
+- outlier detection: `OneClassSVM`
+
+Each model has a detailed document string, which includes examples of
+usage. Document strings can be accessed from MLJ without loading
+`LIBSVM.jl` or its MLJ interface as shown in the following example:
+
+```julia
+using MLJ     # or MLJModels 
+doc("NuSVC", pkg="LIBSVM")
+```
+
+Below we illustrate usage of the classic kernel `SVC` classifier. In
+the example, `X` can be replaced with any table (e.g., `DataFrame`)
+whose columns have `Float64` eltype. The target `y` can be any
+`CategoricalVector`.
+
+### Using a built-in kernel
+
+```
+using MLJ
+import LIBSVM
+
+SVC = @load SVC pkg=LIBSVM                   # model type
+model = SVC(kernel=LIBSVM.Kernel.Polynomial) # instance
+
+X, y = @load_iris # table, vector
+mach = machine(model, X, y) |> fit!
+
+Xnew = (sepal_length = [6.4, 7.2, 7.4],
+        sepal_width = [2.8, 3.0, 2.8],
+        petal_length = [5.6, 5.8, 6.1],
+        petal_width = [2.1, 1.6, 1.9],)
+
+julia> yhat = predict(mach, Xnew)
+3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
+ "virginica"
+ "virginica"
+ "virginica"
+```
+
+### User-defined kernels
+
+```
+k(x1, x2) = x1'*x2 # equivalent to `LIBSVM.Kernel.Linear`
+model = SVC(kernel=k)
+mach = machine(model, X, y) |> fit!
+
+julia> yhat = predict(mach, Xnew)
+3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
+ "virginica"
+ "virginica"
+ "virginica"
+```
+
+### Incorporating class weights
+
+In either scenario above, we can do:
+
+```julia
+weights = Dict("virginica" => 1, "versicolor" => 20, "setosa" => 1)
+mach = machine(model, X, y, weights) |> fit!
+
+julia> yhat = predict(mach, Xnew)
+3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
+ "versicolor"
+ "versicolor"
+ "versicolor"
+```
+
 
 ## Credits
 


### PR DESCRIPTION
I suspect LIBSVM.jl does not actually test the linear model interface it provides. However, I have locally run MLJLIBSVMInterface.jl tests with LIBLINEAER 0.7, which do test the linear model. So that's some comfort, at least. 


This PR also drops support for Julia < 1.6