### PR TITLE
Test: cover LIBLINEAR usage

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,6 @@ end
 end
 
 @testset "IRIS" begin
-    @info "test iris"
     instances, labels = load_iris()
     model = svmtrain(instances[:, 1:2:end], labels[1:2:end]; verbose = true)
     GC.gc()
@@ -53,8 +52,6 @@ end
 end
 
 @testset "AbstractVector as labels" begin
-    @info "test AbstractVector labels"
-
     iris = dataset("datasets", "iris")
     X = Matrix(iris[:, 1:4])'
     y = iris.Species
@@ -72,8 +69,6 @@ end
 end
 
 @testset "JLD2 save/load" begin
-    @info "JLD2 save/load"
-
     iris = dataset("datasets", "iris")
     X = Matrix(iris[:, 1:4])'
     y = iris.Species
@@ -104,11 +99,24 @@ end
     end
 end
 
+@testset "LinearSVC" begin
+    svm = LinearSVC()
+    # Linearly-separable points
+    X = [-1 -1;
+         -2 -2;
+          1  1;
+          2  2]
+    y = [1, 1, 2, 2]
+
+    fit!(svm, X, y)
+    @test !isnothing(svm.fit)
+
+    yhat = predict(svm, X)
+    @test y == yhat
+end
 
 @testset "Whiteside" begin
     #Regression tests, results confirmed using e1071 R-package
-    @info "test Whiteside"
-
     whiteside = RDatasets.dataset("MASS", "whiteside")
     ws = Matrix{Float64}(whiteside[:,2:3])
     X = Array{Float64, 2}(ws[:, 2]')
@@ -342,7 +350,7 @@ end
 
         X = [0.72  0.68  0.28  0.75  0.47  0.26  0.95  0.0   0.95  0.39;
              0.49  0.07  0.67  0.94  0.4   0.98  0.21  0.29  0.91  0.16]
-        
+
         y = 0.5 .< [distance(x) for x ∈ eachcol(X)]
 
         kernel(x1, x2) = x1' * x2 + distance(x1) * distance(x2)
@@ -353,7 +361,7 @@ end
 
         T = [0.57  0.56  0.57  0.51;
              0.9   0.37  0.04  0.76]
-        
+
         ŷ = 0.5 .< [distance(x) for x ∈ eachcol(T)]
         ỹ, _  = svmpredict(model, T)
 


### PR DESCRIPTION
I verified that the added test errors with LIBLINEARv0.6. With LIBLINEARv0.7, the test passes.

Curiously, LIBLINEAR is only used when fitting LinearSVC through the "scikit" API (never through `svmtrain`/`svmpredict`).

Resolves #98